### PR TITLE
feat: include plugins-node-all metapackage by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@opentelemetry/core": "^0.10.2",
     "@opentelemetry/exporter-collector": "^0.10.2",
     "@opentelemetry/node": "^0.10.2",
+    "@opentelemetry/plugins-node-all": "^0.10.2",
     "@opentelemetry/resources": "^0.10.2",
     "@opentelemetry/sdk-node": "^0.10.2"
   },


### PR DESCRIPTION
This PR adds the plugins-node-all package by default. This will spare users from having to install it and allow us to ship a version of the sdk, api, and plugins that are compatible with each other.