### PR TITLE
chore: simplify types for configuration and env

### DIFF
--- a/src/lightstep-opentelemetry-launcher-node.ts
+++ b/src/lightstep-opentelemetry-launcher-node.ts
@@ -49,7 +49,7 @@ const LS_DEFAULTS: Partial<types.LightstepNodeSDKConfiguration> = {
   spanEndpoint: 'https://ingest.lightstep.com:443/api/v2/otel/trace',
   metricEndpoint: 'https://ingest.lightstep.com/metrics/otlp/v0.5',
   propagators: PROPAGATION_FORMATS.B3,
-  metricsHostEnabled: 'true',
+  metricsHostEnabled: true,
 };
 
 const ACCESS_TOKEN_HEADER = 'Lightstep-Access-Token';
@@ -90,7 +90,7 @@ function patchSDK(
   sdk: NodeSDK,
   config: Partial<types.LightstepNodeSDKConfiguration>
 ): NodeSDK {
-  if (!config.metricExporter || config.metricsHostEnabled !== 'true') {
+  if (!config.metricExporter || !config.metricsHostEnabled) {
     return sdk;
   }
   const originalStart = sdk.start;
@@ -183,17 +183,19 @@ function logConfig(
  * keys using lightstep conventions
  */
 function configFromEnvironment(): Partial<types.LightstepNodeSDKConfiguration> {
-  const env = process.env as types.LightstepEnv;
-  return Object.entries(types.LS_OPTION_ALIAS_MAP).reduce(
-    (acc, [envName, optName]) => {
-      const value = env[envName as keyof types.LightstepEnv];
-      if (typeof value !== 'undefined' && optName) {
-        acc[optName] = value;
-      }
-      return acc;
-    },
-    {} as types.LightstepConfigType
-  );
+  const env: types.LightstepEnv = process.env;
+  const envConfig: Partial<types.LightstepNodeSDKConfiguration> = {};
+  if (env.LS_ACCESS_TOKEN) envConfig.accessToken = env.LS_ACCESS_TOKEN;
+  if (env.LS_METRICS_HOST_ENABLED)
+    envConfig.metricsHostEnabled = env.LS_METRICS_HOST_ENABLED === 'true';
+  if (env.LS_SERVICE_NAME) envConfig.serviceName = env.LS_SERVICE_NAME;
+  if (env.LS_SERVICE_VERSION) envConfig.serviceVersion = env.LS_SERVICE_VERSION;
+  if (env.OTEL_EXPORTER_OTLP_SPAN_ENDPOINT)
+    envConfig.spanEndpoint = env.OTEL_EXPORTER_OTLP_SPAN_ENDPOINT;
+  if (env.OTEL_EXPORTER_OTLP_METRIC_ENDPOINT)
+    envConfig.metricEndpoint = env.OTEL_EXPORTER_OTLP_METRIC_ENDPOINT;
+  if (env.OTEL_PROPAGATORS) envConfig.propagators = env.OTEL_PROPAGATORS;
+  return envConfig;
 }
 
 /**
@@ -309,7 +311,7 @@ function configureMetricExporter(
 function configureHostMetrics(
   config: Partial<types.LightstepNodeSDKConfiguration>
 ) {
-  if (config.metricsHostEnabled !== 'true') {
+  if (!config.metricsHostEnabled) {
     return;
   }
   const meterProvider = metrics.getMeterProvider();

--- a/src/lightstep-opentelemetry-launcher-node.ts
+++ b/src/lightstep-opentelemetry-launcher-node.ts
@@ -90,7 +90,7 @@ function patchSDK(
   sdk: NodeSDK,
   config: Partial<types.LightstepNodeSDKConfiguration>
 ): NodeSDK {
-  if (!config.metricExporter || !config.metricsHostEnabled) {
+  if (!config.metricExporter || config.metricsHostEnabled !== true) {
     return sdk;
   }
   const originalStart = sdk.start;
@@ -311,7 +311,7 @@ function configureMetricExporter(
 function configureHostMetrics(
   config: Partial<types.LightstepNodeSDKConfiguration>
 ) {
-  if (!config.metricsHostEnabled) {
+  if (!config.metricsHostEnabled !== true) {
     return;
   }
   const meterProvider = metrics.getMeterProvider();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,25 +1,30 @@
 import { NodeSDKConfiguration } from '@opentelemetry/sdk-node';
 
-/** Mapping of environment variable names to LightstepNodeSDKConfiguration names */
-export enum LS_OPTION_ALIAS_MAP {
-  LS_ACCESS_TOKEN = 'accessToken',
-  LS_METRICS_HOST_ENABLED = 'metricsHostEnabled',
-  LS_SERVICE_NAME = 'serviceName',
-  LS_SERVICE_VERSION = 'serviceVersion',
-  OTEL_EXPORTER_OTLP_SPAN_ENDPOINT = 'spanEndpoint',
-  OTEL_EXPORTER_OTLP_METRIC_ENDPOINT = 'metricEndpoint',
-  OTEL_PROPAGATORS = 'propagators',
+/** Lightstep specific configuration options */
+export interface LightstepConfigType {
+  accessToken?: string;
+  metricsHostEnabled?: boolean;
+  serviceName?: string;
+  serviceVersion?: string;
+  spanEndpoint?: string;
+  metricEndpoint?: string;
+  propagators?: string;
 }
 
-export type LightstepEnvType = {
-  [key in keyof typeof LS_OPTION_ALIAS_MAP]: string;
-};
-export type LightstepConfigType = Record<LS_OPTION_ALIAS_MAP, string>;
+/** Lightstep environment variable names */
+export interface LightstepEnvType {
+  LS_ACCESS_TOKEN?: string;
+  LS_METRICS_HOST_ENABLED?: string;
+  LS_SERVICE_NAME?: string;
+  LS_SERVICE_VERSION?: string;
+  OTEL_EXPORTER_OTLP_SPAN_ENDPOINT?: string;
+  OTEL_EXPORTER_OTLP_METRIC_ENDPOINT?: string;
+  OTEL_PROPAGATORS?: string;
+}
+
+export type LightstepEnv = Partial<LightstepEnvType>;
 
 export type FailureHandler = (message: string) => void;
-
-/** Lightstep environment variable names */
-export type LightstepEnv = Partial<LightstepEnvType>;
 
 /** Lightstep flavored configuration for the OpenTelemetry JS SDK */
 export interface LightstepNodeSDKConfiguration


### PR DESCRIPTION
This PR simplifies the lightstep specific config and reading it from the the environment. This makes things a little more manual, but more flexible as a result. This allows us to treat `LS_METRICS_HOST_ENABLED` as a boolean rather than a string as discussed in #25.