### PR TITLE
fix span status and host metrics config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Sends spans to an updated OTLP ingest endpoint that properly handles span
+  status for OTLP v0.6. Fixes issue [#33](https://github.com/lightstep/otel-launcher-node/issues/33).
+* Fixes configuration related bug that results in host metrics being disabled
+  by default.
+
 ## 0.13.0
 
 * Dependencies have been upgraded to the latest OpenTelemetry JS versions

--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ sdk.start().then(() => {
 
 ### Configuration Options
 
-| Config Option        | Env Variable                       | Required | Default                                            |
-| -------------------- | ---------------------------------- | -------- | -------------------------------------------------- |
-| serviceName          | LS_SERVICE_NAME                    | y        | -                                                  |
-| serviceVersion       | LS_SERVICE_VERSION                 | n        | unknown                                            |
-| spanEndpoint         | OTEL_EXPORTER_OTLP_SPAN_ENDPOINT   | n        | https://ingest.lightstep.com:443/api/v2/otel/trace |
-| metricEndpoint       | OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | n        | https://ingest.lightstep.com:443/metrics           |
-| accessToken          | LS_ACCESS_TOKEN                    | n        | -                                                  |
-| logLevel             | OTEL_LOG_LEVEL                     | n        | info                                               |
-| propagators          | OTEL_PROPAGATORS                   | n        | b3                                                 |
-| resource             | OTEL_RESOURCE_ATTRIBUTES           | n        | -                                                  |
-| metricsHostEnabled   | LS_METRICS_HOST_ENABLED            | n        | true                                               |
+| Config Option      | Env Variable                       | Required | Default                                        |
+| ------------------ | ---------------------------------- | -------- | ---------------------------------------------- |
+| serviceName        | LS_SERVICE_NAME                    | y        | -                                              |
+| serviceVersion     | LS_SERVICE_VERSION                 | n        | unknown                                        |
+| spanEndpoint       | OTEL_EXPORTER_OTLP_SPAN_ENDPOINT   | n        | https://ingest.lightstep.com/traces/otlp/v0.6  |
+| metricEndpoint     | OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | n        | https://ingest.lightstep.com/metrics/otlp/v0.6 |
+| accessToken        | LS_ACCESS_TOKEN                    | n        | -                                              |
+| logLevel           | OTEL_LOG_LEVEL                     | n        | info                                           |
+| propagators        | OTEL_PROPAGATORS                   | n        | b3                                             |
+| resource           | OTEL_RESOURCE_ATTRIBUTES           | n        | -                                              |
+| metricsHostEnabled | LS_METRICS_HOST_ENABLED            | n        | true                                           |
 
 #### Additional Options
 

--- a/src/lightstep-opentelemetry-launcher-node.ts
+++ b/src/lightstep-opentelemetry-launcher-node.ts
@@ -46,8 +46,8 @@ const PROPAGATOR_LOOKUP_MAP: {
 
 /** Default values for LightstepNodeSDKConfiguration */
 const LS_DEFAULTS: Partial<types.LightstepNodeSDKConfiguration> = {
-  spanEndpoint: 'https://ingest.lightstep.com:443/api/v2/otel/trace',
-  metricEndpoint: 'https://ingest.lightstep.com/metrics/otlp/v0.5',
+  spanEndpoint: 'https://ingest.lightstep.com/traces/otlp/v0.6',
+  metricEndpoint: 'https://ingest.lightstep.com/metrics/otlp/v0.6',
   propagators: PROPAGATION_FORMATS.B3,
   metricsHostEnabled: true,
 };

--- a/src/lightstep-opentelemetry-launcher-node.ts
+++ b/src/lightstep-opentelemetry-launcher-node.ts
@@ -311,7 +311,7 @@ function configureMetricExporter(
 function configureHostMetrics(
   config: Partial<types.LightstepNodeSDKConfiguration>
 ) {
-  if (!config.metricsHostEnabled !== true) {
+  if (config.metricsHostEnabled !== true) {
     return;
   }
   const meterProvider = metrics.getMeterProvider();


### PR DESCRIPTION
This PR updates the OTLP endpoints for both spans and metrics. The update to span endpoint fixes #33 as the new endpoint will properly handle status for OTLP v0.6. The update to the metrics endpoint is cosmetic, since there were no changes between v0.5 and v0.6 for metrics. Additionally, this PR fixes a configuration bug for host metrics. It's unlikely that any users were getting host metrics with v0.13.0.