### PR TITLE
chore: update core deps to v0.15.0 and contrib to v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+* Opentelemetry dependencies have been upgraded to v0.15.0 for core components
+  and v0.13.0 for contrib.
 
 ## 0.13.1
 

--- a/package.json
+++ b/package.json
@@ -46,15 +46,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.14.0",
-    "@opentelemetry/core": "^0.14.0",
-    "@opentelemetry/exporter-collector": "^0.14.0",
-    "@opentelemetry/host-metrics": "^0.12.0",
-    "@opentelemetry/node": "^0.14.0",
-    "@opentelemetry/propagator-b3": "^0.14.0",
-    "@opentelemetry/plugins-node-core-and-contrib": "^0.12.0",
-    "@opentelemetry/resources": "^0.14.0",
-    "@opentelemetry/sdk-node": "^0.14.0"
+    "@opentelemetry/api": "^0.15.0",
+    "@opentelemetry/api-metrics": "^0.15.0",
+    "@opentelemetry/core": "^0.15.0",
+    "@opentelemetry/exporter-collector": "^0.15.0",
+    "@opentelemetry/host-metrics": "^0.13.0",
+    "@opentelemetry/node": "^0.15.0",
+    "@opentelemetry/propagator-b3": "^0.15.0",
+    "@opentelemetry/plugins-node-core-and-contrib": "^0.13.0",
+    "@opentelemetry/resources": "^0.15.0",
+    "@opentelemetry/sdk-node": "^0.15.0"
   },
   "devDependencies": {
     "@types/mocha": "8.0.3",

--- a/src/lightstep-opentelemetry-launcher-node.ts
+++ b/src/lightstep-opentelemetry-launcher-node.ts
@@ -5,7 +5,8 @@ import {
   HttpBaggage,
   HttpTraceContext,
 } from '@opentelemetry/core';
-import { TextMapPropagator, Logger, metrics } from '@opentelemetry/api';
+import { TextMapPropagator, Logger } from '@opentelemetry/api';
+import { metrics } from '@opentelemetry/api-metrics';
 import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import * as types from './types';

--- a/test/lightstep-opentelemetry-launcher-node.test.ts
+++ b/test/lightstep-opentelemetry-launcher-node.test.ts
@@ -3,7 +3,8 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { lightstep, LightstepConfigurationError, LightstepEnv } from '../src';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { trace, metrics, context, propagation } from '@opentelemetry/api';
+import { trace, context, propagation } from '@opentelemetry/api';
+import { metrics } from '@opentelemetry/api-metrics';
 import { CompositePropagator, HttpTraceContext } from '@opentelemetry/core';
 import {
   HOST_RESOURCE,


### PR DESCRIPTION
This PR updates opentelemetry dependencies for launcher to v0.15.0 for core and v0.13.0 for contrib.