### PR TITLE
chore: updating to latest version api 1.0.0-rc.0 core 019 contrib 016

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
+const { DiagLogLevel } = require('@opentelemetry/api');
 const { lightstep, opentelemetry } = require('../build/src/index');
 
 // set access token or use LS_ACCESS_TOKEN environment variable
@@ -9,8 +9,7 @@ const sdk = lightstep.configureOpenTelemetry({
   accessToken,
   serviceName: 'locl-ex',
   metricInterval: 3000,
-  // logLevel: DiagLogLevel.ALL,
-  // metricsHostEnabled: false,
+  logLevel: DiagLogLevel.ALL,
 });
 
 sdk.start().then(() => {

--- a/package.json
+++ b/package.json
@@ -46,16 +46,28 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.0",
-    "@opentelemetry/api-metrics": "^0.18.0",
-    "@opentelemetry/core": "^0.18.0",
-    "@opentelemetry/exporter-collector": "^0.18.0",
-    "@opentelemetry/host-metrics": "^0.14.0",
-    "@opentelemetry/node": "^0.18.0",
-    "@opentelemetry/propagator-b3": "^0.18.0",
-    "@opentelemetry/plugins-node-core-and-contrib": "^0.14.0 ",
-    "@opentelemetry/resources": "^0.18.0",
-    "@opentelemetry/sdk-node": "^0.18.0"
+    "@opentelemetry/api": "^1.0.0-rc.0",
+    "@opentelemetry/api-metrics": "^0.19.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.16.0",
+    "@opentelemetry/core": "^0.19.0",
+    "@opentelemetry/exporter-collector": "^0.19.0",
+    "@opentelemetry/node": "^0.19.0",
+    "@opentelemetry/propagator-b3": "^0.19.0",
+    "@opentelemetry/shim-opentracing": "^0.19.0",
+    "@opentelemetry/resources": "^0.19.0",
+    "@opentelemetry/sdk-node": "^0.19.0",
+    "opentracing": "^0.14.5",
+    "@types/express": "4.17.11",
+    "@types/graphql": "14.5.0",
+    "@types/hapi__hapi": "20.0.8",
+    "@types/ioredis": "4.26.0",
+    "@types/koa": "2.13.1",
+    "@types/koa__router": "8.0.4",
+    "@types/mongodb": "3.6.12",
+    "@types/mysql": "2.15.18",
+    "@types/pg": "7.14.11",
+    "@types/pg-pool": "2.0.2",
+    "@types/redis": "2.8.28"
   },
   "devDependencies": {
     "@types/mocha": "8.0.3",
@@ -72,6 +84,6 @@
     "package-json": "^6.5.0",
     "sinon": "^9.2.1",
     "ts-mocha": "8.0.0",
-    "typescript": "3.9.7"
+    "typescript": "^4.2.4"
   }
 }

--- a/src/lightstep-opentelemetry-launcher-node.ts
+++ b/src/lightstep-opentelemetry-launcher-node.ts
@@ -23,6 +23,8 @@ import {
 
 import * as os from 'os';
 
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
 const PROPAGATION_FORMATS: { [key: string]: types.PropagationFormat } = {
   B3: 'b3',
   B3SINGLE: 'b3single',
@@ -70,6 +72,7 @@ export function configureOpenTelemetry(
   configureBaseResource(config);
   configurePropagation(config);
   configureTraceExporter(config);
+  configureInstrumentations(config);
 
   return new NodeSDK(config);
 }
@@ -236,6 +239,20 @@ function configureBaseResource(
   } else {
     config.resource = baseResource;
   }
+}
+
+/**
+ * Configures instrumentations
+ * @param config
+ */
+function configureInstrumentations(
+  config: Partial<types.LightstepNodeSDKConfiguration>
+) {
+  if (config.instrumentations) {
+    return;
+  }
+
+  config.instrumentations = [getNodeAutoInstrumentations()];
 }
 
 /**


### PR DESCRIPTION
updating to latest versions

Because otel has been upgraded to typescript version 4.x it requires to include types as main dependencies otherwise there is an error during installation. The fix is to add all needed types to dependencies until this is resolved and released as apatch. I have created a PR for that already -> https://github.com/open-telemetry/opentelemetry-js-contrib/pull/468