### PR TITLE
Prep v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 1.2.0
+* This release changes the default export format for launcher from OTLP/JSON to
+  OTLP/proto (e.g. proto over HTTP). Aside from the change in export format, this
+  release is identical to v1.1.0. Users wishing to use OTLP/JSON can use v1.1.0
+  and transition to a vanilla OpenTelemetry SDK setup moving forward.
+
 ## 1.1.0
 
 * This release requires microsatellite version 2022-10-03_20-16-42Z or later

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@opentelemetry/api-metrics": "^0.33.0",
     "@opentelemetry/auto-instrumentations-node": "~0.33.1",
     "@opentelemetry/core": "~1.7.0",
-    "@opentelemetry/exporter-trace-otlp-http": "~0.33.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "~0.33.0",
     "@opentelemetry/propagator-b3": "~1.7.0",
     "@opentelemetry/resource-detector-aws": "~1.1.2",
     "@opentelemetry/resource-detector-gcp": "~0.27.2",

--- a/src/lightstep-opentelemetry-launcher-node.ts
+++ b/src/lightstep-opentelemetry-launcher-node.ts
@@ -14,7 +14,7 @@ import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import * as types from './types';
 import { VERSION } from './version';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { Resource, ResourceAttributes } from '@opentelemetry/resources';
 


### PR DESCRIPTION
This PR changes the export format for launcher from OTLP/JSON to OTLP/proto, which will be the default format going forward. The transition is described in the changelog and on the [docs site](https://docs.lightstep.com/otel/send-otlp-over-http-to-lightstep).